### PR TITLE
Fix the /v1/models API to output proper OpenAI compatible endpoint

### DIFF
--- a/exo/api/chatgpt_api.py
+++ b/exo/api/chatgpt_api.py
@@ -291,7 +291,8 @@ class ChatGPTAPI:
         )
 
   async def handle_get_models(self, request):
-    return web.json_response([{"id": model_name, "object": "model", "owned_by": "exo", "ready": True} for model_name, _ in model_cards.items()])
+    models_list = [{"id": model_name, "object": "model", "owned_by": "exo", "ready": True} for model_name, _ in model_cards.items()]
+    return web.json_response({"object": "list", "data": models_list})
 
   async def handle_post_chat_token_encode(self, request):
     data = await request.json()


### PR DESCRIPTION
Modify the `/v1/models` API to output a proper OpenAI compatible endpoint with an object and a `data` object containing the models list.

* Change the `handle_get_models` method in `exo/api/chatgpt_api.py` to wrap the models list in an object with a `data` field.
* Add an `object` field with the value "list" to the response format.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/metaspartan/exo/pull/1?shareId=eec06114-7504-4239-ae34-792a26b8b3af).